### PR TITLE
Update Dockerfile to use fedora:latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:39
+FROM registry.fedoraproject.org/fedora:44
 LABEL maintainer "Fedora-CI"
 LABEL description="rpmdeplint for fedora-ci"
 


### PR DESCRIPTION
Clearly we are not good at keeping this on a supported version of Fedora, so let's use the latest tag.