### PR TITLE
Really use 'latest' tag for Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:44
+FROM registry.fedoraproject.org/fedora:latest
 LABEL maintainer "Fedora-CI"
 LABEL description="rpmdeplint for fedora-ci"
 


### PR DESCRIPTION
This is what the previous commit was meant to do. I accidentally pushed an earlier version.